### PR TITLE
Break out S3 bucket settings to align with `aws` provider 4.x changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ No modules.
 | aws\_region | The AWS region to deploy into (e.g. us-east-1). | `string` | `"us-east-1"` | no |
 | findings\_data\_bucket\_access\_role\_arn | The ARN of the IAM role that is allowed to access the S3 bucket containing the findings data. | `string` | n/a | yes |
 | findings\_data\_bucket\_object\_key\_pattern | The key pattern specifying which objects are allowed to be written to the findings data S3 bucket. | `string` | `"*-data.json"` | no |
-| findings\_data\_import\_lambda\_s3\_bucket | The name of the bucket where the findings data import lambda function will be stored.  Note that in production terraform workspaces, the string '-production' will be appended to the bucket name.  In non-production workspaces, '-<workspace\_name>' will be appended to the bucket name. | `string` | `"findings-data-import-lambda"` | no |
+| findings\_data\_import\_lambda\_s3\_bucket | The name of the bucket where the findings data import Lambda function will be stored.  Note that in production terraform workspaces, the string '-production' will be appended to the bucket name.  In non-production workspaces, '-<workspace\_name>' will be appended to the bucket name. | `string` | `"findings-data-import-lambda"` | no |
 | findings\_data\_s3\_bucket | The name of the bucket where the findings data JSON file will be stored.  Note that in production terraform workspaces, the string '-production' will be appended to the bucket name.  In non-production workspaces, '-<workspace\_name>' will be appended to the bucket name. | `string` | `"findings-data"` | no |
 | tags | Tags to apply to all AWS resources created. | `map(string)` | `{}` | no |
 

--- a/README.md
+++ b/README.md
@@ -61,13 +61,13 @@ tags = {
 | Name | Version |
 |------|---------|
 | terraform | ~> 1.0 |
-| aws | ~> 3.38 |
+| aws | ~> 3.75 |
 
 ## Providers ##
 
 | Name | Version |
 |------|---------|
-| aws | ~> 3.38 |
+| aws | ~> 3.75 |
 
 ## Modules ##
 
@@ -83,6 +83,10 @@ No modules.
 | [aws_s3_bucket.exported_data](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) | resource |
 | [aws_s3_bucket.fdi_lambda](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) | resource |
 | [aws_s3_bucket_policy.exported_data](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_policy) | resource |
+| [aws_s3_bucket_public_access_block.exported_data](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_public_access_block) | resource |
+| [aws_s3_bucket_public_access_block.fdi_lambda](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_public_access_block) | resource |
+| [aws_s3_bucket_server_side_encryption_configuration.exported_data](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_server_side_encryption_configuration) | resource |
+| [aws_s3_bucket_server_side_encryption_configuration.fdi_lambda](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_server_side_encryption_configuration) | resource |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_iam_policy_document.exported_data_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.exported_data_write_doc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |

--- a/exported_data_bucket.tf
+++ b/exported_data_bucket.tf
@@ -6,19 +6,36 @@ resource "aws_s3_bucket" "exported_data" {
   # '-<workspace_name>' is appended to the bucket name.
   bucket = local.production_workspace ? format("%s-production", var.findings_data_s3_bucket) : format("%s-%s", var.findings_data_s3_bucket, terraform.workspace)
 
-  server_side_encryption_configuration {
-    rule {
-      apply_server_side_encryption_by_default {
-        sse_algorithm = "AES256"
-      }
-    }
-  }
-
   tags = {
     "Name" = "Exported Findings Data"
   }
 
   lifecycle {
+    ignore_changes = [
+      server_side_encryption_configuration
+    ]
     prevent_destroy = true
   }
+}
+
+# Ensure the S3 bucket is encrypted
+resource "aws_s3_bucket_server_side_encryption_configuration" "exported_data" {
+  bucket = aws_s3_bucket.exported_data.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
+# This blocks ANY public access to the bucket or the objects it
+# contains, even if misconfigured to allow public access.
+resource "aws_s3_bucket_public_access_block" "exported_data" {
+  bucket = aws_s3_bucket.exported_data.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
 }

--- a/exported_data_bucket.tf
+++ b/exported_data_bucket.tf
@@ -1,5 +1,5 @@
-# This bucket is used to store a JSON file containing all exported
-# findings data to be imported into our AWS database.
+# This bucket stores JSON files containing exported assessment findings data
+# to be imported into our MongoDB database in AWS.
 resource "aws_s3_bucket" "exported_data" {
   # Note that in production terraform workspaces, the string '-production' is
   # appended to the bucket name.  In non-production workspaces,

--- a/exported_data_bucket.tf
+++ b/exported_data_bucket.tf
@@ -1,10 +1,10 @@
+# This bucket is used to store a JSON file containing all exported
+# findings data to be imported into our AWS database.
 resource "aws_s3_bucket" "exported_data" {
-  # This bucket is used to store a JSON file containing all exported
-  # findings data to be imported into our AWS database.
   # Note that in production terraform workspaces, the string '-production' is
   # appended to the bucket name.  In non-production workspaces,
   # '-<workspace_name>' is appended to the bucket name.
-  bucket = local.production_workspace ? format("%s-production", var.findings_data_s3_bucket) : format("%s-%s", var.findings_data_s3_bucket, terraform.workspace)
+  bucket = format("%s-%s", var.findings_data_s3_bucket, local.production_workspace ? "production" : terraform.workspace)
 
   tags = {
     "Name" = "Exported Findings Data"

--- a/lambda_bucket.tf
+++ b/lambda_bucket.tf
@@ -1,4 +1,4 @@
-# This bucket is used to store the lambda function that imports findings
+# This bucket is used to store the Lambda function that imports findings
 # data from the exported_data bucket into the CyHy database.
 resource "aws_s3_bucket" "fdi_lambda" {
   # Note that in production terraform workspaces, the string '-production' is

--- a/lambda_bucket.tf
+++ b/lambda_bucket.tf
@@ -1,14 +1,10 @@
+# This bucket is used to store the lambda function that imports findings
+# data from the exported_data bucket into the CyHy database.
 resource "aws_s3_bucket" "fdi_lambda" {
-  # This bucket is used to store the lambda function that imports findings
-  # data from the exported_data bucket into the CyHy database.
   # Note that in production terraform workspaces, the string '-production' is
   # appended to the bucket name.  In non-production workspaces,
   # '-<workspace_name>' is appended to the bucket name.
-  bucket = local.production_workspace ? format("%s-production", var.findings_data_import_lambda_s3_bucket) : format(
-    "%s-%s",
-    var.findings_data_import_lambda_s3_bucket,
-    terraform.workspace,
-  )
+  bucket = format("%s-%s", var.findings_data_import_lambda_s3_bucket, local.production_workspace ? "production" : terraform.workspace)
 
   tags = {
     "Name" = "Findings Data Import Lambda"

--- a/locals.tf
+++ b/locals.tf
@@ -1,5 +1,5 @@
 locals {
-  # This is a goofy but necessary way to determine if
-  # terraform.workspace contains the substring "prod"
-  production_workspace = replace(terraform.workspace, "prod", "") != terraform.workspace
+  # Determine if this is a Production workspace by checking
+  # if terraform.workspace begins with "prod-"
+  production_workspace = length(regexall("^prod-", terraform.workspace)) == 1
 }

--- a/variables.tf
+++ b/variables.tf
@@ -29,7 +29,7 @@ variable "findings_data_bucket_object_key_pattern" {
 
 variable "findings_data_import_lambda_s3_bucket" {
   type        = string
-  description = "The name of the bucket where the findings data import lambda function will be stored.  Note that in production terraform workspaces, the string '-production' will be appended to the bucket name.  In non-production workspaces, '-<workspace_name>' will be appended to the bucket name."
+  description = "The name of the bucket where the findings data import Lambda function will be stored.  Note that in production terraform workspaces, the string '-production' will be appended to the bucket name.  In non-production workspaces, '-<workspace_name>' will be appended to the bucket name."
   default     = "findings-data-import-lambda"
 }
 

--- a/versions.tf
+++ b/versions.tf
@@ -6,12 +6,12 @@ terraform {
   # major version currently being used.  This practice will help us
   # avoid unwelcome surprises.
   required_providers {
-    # Version 3.38.0 of the Terraform AWS provider is the first
-    # version to support default tags.
-    # https://www.hashicorp.com/blog/default-tags-in-the-terraform-aws-provider
+    # Version 3.75.0 of the Terraform AWS provider backports the changes to how
+    # AWS S3 resources are structured from the 4.0 release.
+    # https://www.hashicorp.com/blog/terraform-aws-provider-4-0-refactors-s3-bucket-resource
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 3.38"
+      version = "~> 3.75"
     }
   }
 }


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request does the following:
1. Update bucket name generation to be saner.
2. Break out S3 bucket setting attributes into their own corresponding resources.
3. Change the bucket access permissions to reject all forms of public access by default.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

We need to make changes in support of the `aws` provider 4.x version that have been backported into the 3.x version to support migrating our base provider version to 4.x as a development team. The name generation for the bucket names was overly complicated so they were updated. Lastly both buckets may contain sensitive data so it's best to block public access as a default action.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Automated tests pass. This has been applied in my test environment (and apparently a production environment) without issue.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [x] All new and existing tests pass.
