### PR TITLE
Enforce S3 object ownership and make the exported data policy optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | aws\_region | The AWS region to deploy into (e.g. us-east-1). | `string` | `"us-east-1"` | no |
-| findings\_data\_bucket\_access\_role\_arn | The ARN of the IAM role that is allowed to access the S3 bucket containing the findings data. | `string` | n/a | yes |
+| findings\_data\_bucket\_access\_role\_arn | The ARN of the IAM role that is allowed to access the S3 bucket containing the findings data. | `string` | `""` | no |
 | findings\_data\_bucket\_object\_key\_pattern | The key pattern specifying which objects are allowed to be written to the findings data S3 bucket. | `string` | `"*-data.json"` | no |
 | findings\_data\_import\_lambda\_s3\_bucket | The name of the bucket where the findings data import Lambda function will be stored.  Note that in production terraform workspaces, the string '-production' will be appended to the bucket name.  In non-production workspaces, '-<workspace\_name>' will be appended to the bucket name. | `string` | `"findings-data-import-lambda"` | no |
 | findings\_data\_s3\_bucket | The name of the bucket where the findings data JSON file will be stored.  Note that in production terraform workspaces, the string '-production' will be appended to the bucket name.  In non-production workspaces, '-<workspace\_name>' will be appended to the bucket name. | `string` | `"findings-data"` | no |

--- a/README.md
+++ b/README.md
@@ -82,6 +82,8 @@ No modules.
 | [aws_iam_user_policy.exported_data_write_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_user_policy) | resource |
 | [aws_s3_bucket.exported_data](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) | resource |
 | [aws_s3_bucket.fdi_lambda](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) | resource |
+| [aws_s3_bucket_ownership_controls.exported_data](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_ownership_controls) | resource |
+| [aws_s3_bucket_ownership_controls.fdi_lambda](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_ownership_controls) | resource |
 | [aws_s3_bucket_policy.exported_data](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_policy) | resource |
 | [aws_s3_bucket_public_access_block.exported_data](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_public_access_block) | resource |
 | [aws_s3_bucket_public_access_block.fdi_lambda](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_public_access_block) | resource |

--- a/exported_data_bucket.tf
+++ b/exported_data_bucket.tf
@@ -39,3 +39,15 @@ resource "aws_s3_bucket_public_access_block" "exported_data" {
   ignore_public_acls      = true
   restrict_public_buckets = true
 }
+
+# Any objects placed into this bucket should be owned by the bucket
+# owner. This ensures that even if objects are Put by a different
+# account the bucket owning account retains full control over the
+# objects stored here.
+resource "aws_s3_bucket_ownership_controls" "exported_data" {
+  bucket = aws_s3_bucket.exported_data.id
+
+  rule {
+    object_ownership = "BucketOwnerEnforced"
+  }
+}

--- a/exported_data_bucket.tf
+++ b/exported_data_bucket.tf
@@ -41,9 +41,9 @@ resource "aws_s3_bucket_public_access_block" "exported_data" {
 }
 
 # Any objects placed into this bucket should be owned by the bucket
-# owner. This ensures that even if objects are Put by a different
-# account the bucket owning account retains full control over the
-# objects stored here.
+# owner. This ensures that even if objects are added by a different
+# account, the bucket-owning account retains full control over the
+# objects stored in this bucket.
 resource "aws_s3_bucket_ownership_controls" "exported_data" {
   bucket = aws_s3_bucket.exported_data.id
 

--- a/exported_data_bucket_policy.tf
+++ b/exported_data_bucket_policy.tf
@@ -1,9 +1,13 @@
 resource "aws_s3_bucket_policy" "exported_data" {
+  count = local.allow_external_access
+
   bucket = aws_s3_bucket.exported_data.id
-  policy = data.aws_iam_policy_document.exported_data_bucket.json
+  policy = data.aws_iam_policy_document.exported_data_bucket[0].json
 }
 
 data "aws_iam_policy_document" "exported_data_bucket" {
+  count = local.allow_external_access
+
   statement {
     principals {
       type        = "AWS"

--- a/lambda_bucket.tf
+++ b/lambda_bucket.tf
@@ -41,9 +41,9 @@ resource "aws_s3_bucket_public_access_block" "fdi_lambda" {
 }
 
 # Any objects placed into this bucket should be owned by the bucket
-# owner. This ensures that even if objects are Put by a different
-# account the bucket owning account retains full control over the
-# objects stored here.
+# owner. This ensures that even if objects are added by a different
+# account, the bucket-owning account retains full control over the
+# objects stored in this bucket.
 resource "aws_s3_bucket_ownership_controls" "fdi_lambda" {
   bucket = aws_s3_bucket.fdi_lambda.id
 

--- a/lambda_bucket.tf
+++ b/lambda_bucket.tf
@@ -39,3 +39,15 @@ resource "aws_s3_bucket_public_access_block" "fdi_lambda" {
   ignore_public_acls      = true
   restrict_public_buckets = true
 }
+
+# Any objects placed into this bucket should be owned by the bucket
+# owner. This ensures that even if objects are Put by a different
+# account the bucket owning account retains full control over the
+# objects stored here.
+resource "aws_s3_bucket_ownership_controls" "fdi_lambda" {
+  bucket = aws_s3_bucket.fdi_lambda.id
+
+  rule {
+    object_ownership = "BucketOwnerEnforced"
+  }
+}

--- a/locals.tf
+++ b/locals.tf
@@ -2,4 +2,7 @@ locals {
   # Determine if this is a Production workspace by checking
   # if terraform.workspace begins with "prod-"
   production_workspace = length(regexall("^prod-", terraform.workspace)) == 1
+
+  # Determine if we should create the exported data bucket access policy
+  allow_external_access = var.findings_data_bucket_access_role_arn != "" ? 1 : 0
 }

--- a/variables.tf
+++ b/variables.tf
@@ -4,11 +4,6 @@
 # You must provide a value for each of these parameters.
 # ------------------------------------------------------------------------------
 
-variable "findings_data_bucket_access_role_arn" {
-  type        = string
-  description = "The ARN of the IAM role that is allowed to access the S3 bucket containing the findings data."
-}
-
 # ------------------------------------------------------------------------------
 # OPTIONAL PARAMETERS
 #
@@ -19,6 +14,12 @@ variable "aws_region" {
   type        = string
   description = "The AWS region to deploy into (e.g. us-east-1)."
   default     = "us-east-1"
+}
+
+variable "findings_data_bucket_access_role_arn" {
+  type        = string
+  description = "The ARN of the IAM role that is allowed to access the S3 bucket containing the findings data."
+  default     = ""
 }
 
 variable "findings_data_bucket_object_key_pattern" {


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request does the following:
- Enforce that the bucket owner also owns any objects that are stored in the bucket for both the Lambda artifact and exported data buckets.
- Make the policy that allows a specified ARN permission to put objects in the exported data bucket optional.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

We both should (based on AWS recommendations) and must (to ensure Lambda functionality) ensure that the account that owns these buckets also own the objects stored in them. Otherwise anything in the owning account that wishes to access objects pushed from other accounts would need explicit permissions created. This is undesirable for a multitude of reasons so we instead enforce object ownership.

When creating these resources in non-production workspaces it doesn't make sense to enforce allowing a specified ARN access to the exported data bucket.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Automated tests pass. I was able to successfully apply this updated configuration in both my testing and the production workspaces. I also observed that in the production bucket objects that were previously owned by another account had their ownership changed to the account that owns the bucket. I was also able to interact with these objects normally with my creds and the AWS CLI after this change whereas before I lacked appropriate permissions (all actions I tried resulted in a permission denied response).

### ⚠ Note ###

~~I am still waiting for a fresh push from the external account to verify expected functionality.~~ After a re-push objects landed with expected ownership and triggered processing proceeded as expected.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [x] All new and existing tests pass.
